### PR TITLE
Upgrade to ServiceStack 6.3

### DIFF
--- a/src/ServiceStack.Quartz.Tests/ServiceStack.Quartz.Tests.csproj
+++ b/src/ServiceStack.Quartz.Tests/ServiceStack.Quartz.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="ServiceStack" Version="5.8.0" />
+    <PackageReference Include="ServiceStack" Version="6.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/src/ServiceStack.Quartz/ServiceStack.Quartz.csproj
+++ b/src/ServiceStack.Quartz/ServiceStack.Quartz.csproj
@@ -19,11 +19,11 @@
     <RepositoryUrl>https://github.com/wwwlicious/ServiceStack.Quartz</RepositoryUrl>
     <LangVersion>default</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net472|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NET472;</DefineConstants>
     <DocumentationFile>bin\Debug\net472\ServiceStack.Quartz.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net472|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NET472</DefineConstants>
     <DocumentationFile>bin\Release\net472\ServiceStack.Quartz.xml</DocumentationFile>
   </PropertyGroup>

--- a/src/ServiceStack.Quartz/ServiceStack.Quartz.csproj
+++ b/src/ServiceStack.Quartz/ServiceStack.Quartz.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <Description>Easy job scheduling for ServiceStack - https://wwwlicious.github.io/ServiceStack.Quartz/</Description>
     <Authors>Scott Mackay (@wwwlicious)</Authors>
@@ -20,12 +20,12 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net452|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NET452;</DefineConstants>
-    <DocumentationFile>bin\Debug\net452\ServiceStack.Quartz.xml</DocumentationFile>
+    <DefineConstants>TRACE;DEBUG;NET472;</DefineConstants>
+    <DocumentationFile>bin\Debug\net472\ServiceStack.Quartz.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NET452</DefineConstants>
-    <DocumentationFile>bin\Release\net452\ServiceStack.Quartz.xml</DocumentationFile>
+    <DefineConstants>TRACE;DEBUG;NET472</DefineConstants>
+    <DocumentationFile>bin\Release\net472\ServiceStack.Quartz.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NETSTANDARD2_0;</DefineConstants>
@@ -36,8 +36,8 @@
     <DocumentationFile>bin\Release\netstandard2.0\ServiceStack.Quartz.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageReference Include="Quartz" Version="3.0.7" />
-    <PackageReference Include="ServiceStack.Server" Version="5.8.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageReference Include="Quartz" Version="3.4.0" />
+    <PackageReference Include="ServiceStack" Version="6.3.0" />
   </ItemGroup>
 </Project>

--- a/src/demo/ServiceStackQuartz.NetCore/ServiceStack.Quartz.NetCore.csproj
+++ b/src/demo/ServiceStackQuartz.NetCore/ServiceStack.Quartz.NetCore.csproj
@@ -6,11 +6,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />
-    <PackageReference Include="Quartz" Version="3.0.7" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
-    <PackageReference Include="ServiceStack" Version="5.8.0" />
+    <PackageReference Include="ServiceStack" Version="6.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\ServiceStack.Quartz\ServiceStack.Quartz.csproj" />


### PR DESCRIPTION
Per https://forums.servicestack.net/t/typeloadexception-after-upgrade-to-6-3-0/10942 the MetadataFeatureExtensions class was refactored out between 6.1 and 6.3. This requires an upgrade to ServiceStack 6.3